### PR TITLE
Fix to clear error/exception for multiple execute statement

### DIFF
--- a/nzpy/core.py
+++ b/nzpy/core.py
@@ -1762,6 +1762,7 @@ class Connection():
         
     def execute(self, cursor, query, vals):
         
+        self.error = None
         cursor._row_count = -1
         cursor.ps = {'row_desc': []}
 


### PR DESCRIPTION
Issue link: https://github.com/IBM/nzpy/issues/6

Problem: Error/exception is not reset for multiple execute 

Solution: Reset the error/exception for every execute statement

Testing: Tested by executing multiple execute statement where one of them throws exception