### PR TITLE
Fix to support latin-9 code set for char/varchar datatype

### DIFF
--- a/nzpy/__init__.py
+++ b/nzpy/__init__.py
@@ -43,11 +43,11 @@ __author__ = "Mathieu Fenniak"
 def connect(
         user, host='localhost', unix_sock=None, port=5432, database=None, 
         password=None, ssl=None, securityLevel= 0, timeout=None, application_name=None,
-        max_prepared_statements=1000, datestyle = 'ISO', logLevel = 0, tcp_keepalive=True):
+        max_prepared_statements=1000, datestyle = 'ISO', logLevel = 0, tcp_keepalive=True, char_varchar_encoding='latin'):
 
     return Connection(
         user, host, unix_sock, port, database, password, ssl, securityLevel, timeout,
-        application_name, max_prepared_statements, datestyle, logLevel, tcp_keepalive)
+        application_name, max_prepared_statements, datestyle, logLevel, tcp_keepalive,char_varchar_encoding)
 
 
 apilevel = "2.0"

--- a/nzpy/core.py
+++ b/nzpy/core.py
@@ -2013,19 +2013,19 @@ class Connection():
                 memsize = 1
                 
             if fldtype == NzTypeChar:
-                value = str(fieldDataP[:fldlen], self._client_encoding)
+                value = str(fieldDataP[:fldlen], 'latin')
                 row.append(value)
                 logging.debug("field=%d, datatype=CHAR, value=%s", cur_field+1,value)                
                 
-            if fldtype == NzTypeNChar or fldtype == NzTypeVarFixedChar:
+            if fldtype == NzTypeNChar or fldtype == NzTypeNVarChar:
                 cursize  = int.from_bytes(fieldDataP[0:2], 'little') - 2
                 value = str(fieldDataP[2:cursize+2], self._client_encoding)
                 row.append(value)
                 logging.debug("field=%d, datatype=%s, value=%s", cur_field+1,dataType[fldtype], value)                
                 
-            if fldtype == NzTypeVarChar or fldtype == NzTypeNVarChar or fldtype == NzTypeGeometry or fldtype == NzTypeVarBinary:
+            if fldtype == NzTypeVarChar or fldtype == NzTypeVarFixedChar or fldtype == NzTypeGeometry or fldtype == NzTypeVarBinary:
                 cursize  = int.from_bytes(fieldDataP[0:2], 'little') - 2
-                value = str(fieldDataP[2:cursize+2], self._client_encoding)
+                value = str(fieldDataP[2:cursize+2], 'latin')
                 row.append(value)
                 logging.debug("field=%d, datatype=%s, value=%s", cur_field+1,dataType[fldtype], value)
                 

--- a/nzpy/core.py
+++ b/nzpy/core.py
@@ -1144,7 +1144,8 @@ class Connection():
 
     def __init__(
             self, user, host, unix_sock, port, database, password, ssl,
-            securityLevel, timeout, application_name, max_prepared_statements, datestyle, logLevel, tcp_keepalive):
+            securityLevel, timeout, application_name, max_prepared_statements, datestyle, logLevel, tcp_keepalive, char_varchar_encoding):
+        self._char_varchar_encoding = char_varchar_encoding
         self._client_encoding = "utf8"
         self._commands_with_count = (
             b"INSERT", b"DELETE", b"UPDATE"
@@ -2013,7 +2014,7 @@ class Connection():
                 memsize = 1
                 
             if fldtype == NzTypeChar:
-                value = str(fieldDataP[:fldlen], 'latin')
+                value = str(fieldDataP[:fldlen], self._char_varchar_encoding)
                 row.append(value)
                 logging.debug("field=%d, datatype=CHAR, value=%s", cur_field+1,value)                
                 
@@ -2025,7 +2026,7 @@ class Connection():
                 
             if fldtype == NzTypeVarChar or fldtype == NzTypeVarFixedChar or fldtype == NzTypeGeometry or fldtype == NzTypeVarBinary:
                 cursize  = int.from_bytes(fieldDataP[0:2], 'little') - 2
-                value = str(fieldDataP[2:cursize+2], 'latin')
+                value = str(fieldDataP[2:cursize+2], self._char_varchar_encoding)
                 row.append(value)
                 logging.debug("field=%d, datatype=%s, value=%s", cur_field+1,dataType[fldtype], value)
                 


### PR DESCRIPTION
Issue: https://github.com/IBM/nzpy/issues/7

Problem: Char/varchar data type does not supports the ISO Latin-9 code set

Solution: Now user can provide encoding for char/varchar datatype from application. Default value is 'latin'

Testing: Ran sample application with char, varchar datatype containing latin char. Ran nzpy test suite. 