### PR TITLE
Fix to support parameter marker with type None

### DIFF
--- a/nzpy/core.py
+++ b/nzpy/core.py
@@ -1751,6 +1751,8 @@ class Connection():
             elif isinstance(arg, bytes):
                 bytfmt = "x'{}'"                
                 query = query.replace('?', bytfmt.format(arg.decode(self._client_encoding)), 1)                
+            elif arg is None:
+                query = query.replace('?', 'NULL', 1)
             else:
                 query = query.replace('?', str(arg), 1)
         


### PR DESCRIPTION
Issue:https://github.com/IBM/nzpy/issues/8

Problem: Parameter marker doesn't work with type None 

Solution: Added a check that if argument is None, replace it with NULL in the query

Testing: Ran a sample app with parameter marker as None for all datatypes. Ran nzpy testsuite.