### PR TITLE
Fix to prevent ANALYZE flag from being appended in non select query

### DIFF
--- a/nzpy/core.py
+++ b/nzpy/core.py
@@ -1754,7 +1754,7 @@ class Connection():
             else:
                 query = query.replace('?', str(arg), 1)
         
-        if statement.find('select') != -1 or statement.find('SELECT') != -1 :
+        if statement.find('select') == 0 or statement.find('SELECT') == 0 :
             statement = statement + " ANALYZE"
             self.execute(cursor, statement, None)
                         


### PR DESCRIPTION
Issue:https://github.com/IBM/nzpy/issues/9

Problem: ANALYZE flag is appended to non select query incorrectly as the condition checks if query contains 'select' keyword. 

Solution: Instead of checking condition that query contains 'select' keyword, it should check if query starts with 'select' keyword.

Testing: Ran a sample application with query containing 'select' keyword like 'create view user_v as select * from t1' and create external table query. Ran nzpy testsuite.