### PR TITLE
Fix to fetch values correctly while selecting NULL values

### DIFF
--- a/nzpy/core.py
+++ b/nzpy/core.py
@@ -1962,12 +1962,15 @@ class Connection():
         if (numFields % 8) > 0 :
             bitmaplen+=1        
             
-        # We ignore first 2 bytes as that denotes length of message. Now convert hex to dec 
-        hex = data[2:2+bitmaplen].hex()
-        dec = int(hex, 16)
+        bitmap = []
+        for i in range(bitmaplen):
+            # We ignore first 2 bytes as that denotes length of message. Now convert hex to dec 
+            hex = data[2+i:3+i].hex()
+            dec = int(hex, 16)
         
-        # convert dec to binary
-        bitmap = decimalToBinary(dec,bitmaplen*8)
+            # convert dec to binary
+            temp = decimalToBinary(dec,8)
+            bitmap.extend(temp)
                
         field_lf = 0
         cur_field = 0


### PR DESCRIPTION
Issue:https://github.com/IBM/nzpy/issues/13

Problem: Incorrect values returned when selecting NULL values from a user table. Bytes of data from backend which determines null columns was interpreted wrongly. 

Solution: Instead of reading all bytes and converting it to binary, read byte by byte and convert each byte to binary and append in a list

Testing: Ran a sample app that fetch mix of NULL and non NULL values. Ran nzpy testsuite.