### PR TITLE
Fixing undefined variable error

### DIFF
--- a/nzpy/core.py
+++ b/nzpy/core.py
@@ -2224,10 +2224,10 @@ class Connection():
             if status == EXTAB_SOCK_ERROR:
     
                 len = h_unpack(self._read(2))[0]
-                errorMsg = str(self._read(length),self._client_encoding)
+                errorMsg = str(self._read(len),self._client_encoding)
 
                 len = h_unpack(self._read(2))[0]
-                errorObject = str(self._read(length),self._client_encoding)
+                errorObject = str(self._read(len),self._client_encoding)
 
                 logging.warning("unload - ErrorMsg: %s", errorMsg)
                 logging.warning("unload - ErrorObj: %s", errorObject)


### PR DESCRIPTION
The attached changes fixes an error in the relevant code path wherein the variable `length` is not defined and, instead, should be `len` according to the scope.