### PR TITLE
Fix nzpy query hang issue: handle 'Z' after error

### DIFF
--- a/nzpy/core.py
+++ b/nzpy/core.py
@@ -1857,7 +1857,7 @@ class Connection():
                 length = i_unpack(self._read(4))[0]
                 self.error = str(self._read(length),self._client_encoding)
                 self.log.debug ("Response received from backend:%s", self.error)
-                return False
+                continue
             if response == ROW_DESCRIPTION:
                 length = i_unpack(self._read(4))[0]
                 cursor.ps = {'row_desc': []}


### PR DESCRIPTION
JIRA: https://github.com/IBM/nzpy/issues/33

Problem:When query receives an error from backend(i.e. backend response 'E'), after processing error we are not consuming response 'Z' from backend. These bytes remain on socket and causes reading incorrect data for next query and thereby causing nzpy to hang.

Solution: After handling character 'E' from backend continue listening to backend for 'Z' and consume the response.

Testing: Issue happened when running nzbatchbnr testcase or nzalchemy+nzpy testcase. After fix, ran same testcase and issue was not observed.