### PR TITLE
Fix error when using python datetime type as placeholder

### DIFF
--- a/nzpy/core.py
+++ b/nzpy/core.py
@@ -26,7 +26,7 @@ import logging.handlers
 from ipaddress import (
     ip_address, IPv4Address, IPv6Address, ip_network, IPv4Network, IPv6Network)
 from datetime import timezone as Timezone
-
+import datetime
 import enum
 
 # Copyright (c) 2007-2009, Mathieu Fenniak
@@ -1760,13 +1760,15 @@ class Connection():
         statement, make_args = convert_paramstyle(nzpy.paramstyle, query)
         args = make_args(vals)
         placeholderCount = query.count('?')
+        if placeholderCount == 0:
+            return query
         if len(args) >= 65536 :
                 self.log.warning("got %d parameters but PostgreSQL only supports 65535 parameters", len(args))
         if len(args) != placeholderCount :
                 self.log.warning("got %d parameters but the statement requires %d", len(args), placeholderCount)
 	
         for arg in args:
-            if isinstance(arg, str):
+            if isinstance(arg, str) or isinstance(arg, datetime.time) or isinstance(arg, datetime.date) or isinstance(arg, datetime.datetime):
                 strfmt = "'{}'"                
                 query = query.replace('?', strfmt.format(arg), 1)
             elif isinstance(arg, bytes):

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -448,7 +448,7 @@ class testnzpy(unittest.TestCase):
         results = self.cursor.fetchall()
         for c1, c2, c3, c4 in results:
             self.assertEqual(58, c1, "ERROR: Data Difference")
-            self.assertEqual('1982-04-22 00:00:00.00', c2, "ERROR: Data Difference")
+            self.assertEqual('1982-04-22 00:00:00.000000', c2, "ERROR: Data Difference")
             self.assertEqual('1982-04-22', c3, "ERROR: Data Difference")
             self.assertEqual('1982-04-22', c4, "ERROR: Data Difference")
 
@@ -626,7 +626,7 @@ class testnzpy(unittest.TestCase):
         self.cursor.execute("SELECT  (dateCol + INTERVAL '@ 1DAY') AS next_date FROM test1")
         results = self.cursor.fetchall()
         for c1 in results:
-            self.assertEqual(['9999-12-31 00:00:00.00'], c1, "ERROR: Data Difference")
+            self.assertEqual(['9999-12-31 00:00:00.000000'], c1, "ERROR: Data Difference")
         self.cursor.execute("DELETE FROM test1")
         self.cursor.execute("INSERT INTO test1 VALUES ('48010301 BC')")
         self.cursor.execute("SELECT * FROM test1")

--- a/tests/test_typeconversion.py
+++ b/tests/test_typeconversion.py
@@ -19,14 +19,14 @@ import pdb
 # Type conversion tests
 
 def testTimeRoundtrip(cursor):
-    cursor.execute("SELECT '?' as f1", (Time(4, 5, 6),))
+    cursor.execute("SELECT ? as f1", (Time(4, 5, 6),))
     retval = cursor.fetchall()
     assert retval[0][0] == '04:05:06'
 
 
 def test_date_roundtrip(cursor):
     v = Date(2001, 2, 3)
-    cursor.execute("SELECT '?' as f1", (v,))
+    cursor.execute("SELECT ? as f1", (v,))
     retval = cursor.fetchall()
     assert retval[0][0] == '2001-02-03' 
 
@@ -127,7 +127,7 @@ def test_int_roundtrip(cursor):
 
 def test_timestamp_roundtrip(is_java, cursor):
     v = Datetime(2001, 2, 3, 4, 5, 6, 170000)
-    cursor.execute("SELECT '?' as f1", (v,))
+    cursor.execute("SELECT ? as f1", (v,))
     retval = cursor.fetchall()
     assert retval[0][0] == '2001-02-03 04:05:06.170000' 
 
@@ -138,7 +138,7 @@ def test_timestamp_roundtrip(is_java, cursor):
         os.environ['TZ'] = "America/Edmonton"
         time.tzset()
 
-        cursor.execute("SELECT '?' as f1", (v,))
+        cursor.execute("SELECT ? as f1", (v,))
         retval = cursor.fetchall()
         assert retval[0][0] == '2001-02-03 04:05:06.170000' 
 


### PR DESCRIPTION
JIRA: https://github.com/IBM/nzpy/issues/35

Problem: Nzpy throws error when using python datetime type as placeholder . For e.g:
```

import nzpy
from datetime import ( datetime as Datetime)

conn = nzpy.connect(user="admin", password="password",host='localhost', port=5480, database="db1", securityLevel=0,logLevel=0, logOptions=nzpy.LogOptions.Logfile)

    with conn.cursor() as cursor:
        v = Datetime(2001, 2, 3, 4, 5, 6, 170000)
        cursor.execute("select ? as f1",(v,))
        for i in cursor.fetchall():
            print(i)
```

Solution: 
1. Add change in Prepare() to check if columns type is instance of date, time or datetime.
2. Added change to check if no placeholder in query then ANALYZE flag should not be added.

Testing:  Ran sample application where error observed. Ran nzpy test suite.