### PR TITLE
Fix to handle backend notices just after connection completes

### DIFF
--- a/nzpy/handshake.py
+++ b/nzpy/handshake.py
@@ -524,12 +524,17 @@ class Handshake():
             self.log.debug("backend response: %s", response)
             
             if response != core.AUTHENTICATION_REQUEST:
-                _read(8) # do not use just ignore
+                _read(4) # do not use just ignore
+                length = core.i_unpack(_read(4))[0]
             
             if response == core.AUTHENTICATION_REQUEST:
                 areq = core.i_unpack(_read(4))[0]
                 self.log.debug("backend response: %s", areq)
-    
+
+            if response == core.NOTICE_RESPONSE:
+                notices = str(_read(length),'utf8')
+                self.log.debug ("Response received from backend:%s", notices)
+
             if response == core.BACKEND_KEY_DATA:
                 
                 areq = core.i_unpack(_read(4))[0]
@@ -543,7 +548,8 @@ class Handshake():
                 return True
             
             if response == core.ERROR_RESPONSE:
-                self.log.warning("Error occured, server response")
+                error = str(_read(length),'utf8')
+                self.log.warning("Error occured, server response:%s", error)
                 return False
    
     


### PR DESCRIPTION
JIRA: https://github.com/IBM/nzpy/issues/39

Problem: It is observed that in some cases, nzpy hangs if backend sends notice just after handshake/connection setup completion. For e.g: due to some issue in system, a notice is sent everytime nzsql is fired.

```
[nz@ipshost-0 nzbatchbnr_test]$ nzsql -l
NOTICE:  SET PATH: unable to locate the schema / database 'SQLEXT'
  List of databases
   DATABASE   | OWNER
--------------+-------
 SYSTEM       | ADMIN
 TPCDS100_BNR | ADMIN
(2 rows)

```

Solution: Handle notice 'N' from backend in conn_connection_complete() and log the notice. 

Testing: Tested this on system where the above problem was observed. After fix, this issue was not observed. 
Ran nzpy testcase.

