### PR TITLE
Fix to support JSON/JSONB/JSONPATH datatypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-nzpy is a pure-Python IBM Netezza driver that complies with DB-API 2.0. It is tested on Python versions 3.5+. It is supported with NPS 11.1.2.x and later. 
+nzpy is a pure-Python IBM Netezza driver that complies with DB-API 2.0. It is tested on Python versions 3.5+. It is supported with NPS 11.1.2.x and later. Although nzpy works with older NPS versions but it do not support few features such as external table, parameter style query etc.
 
 ## Installation
 To install nzpy using pip type:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-nzpy is a pure-Python IBM Netezza driver that complies with DB-API 2.0. It is tested on Python versions 3.5+. 
+nzpy is a pure-Python IBM Netezza driver that complies with DB-API 2.0. It is tested on Python versions 3.5+. It is supported with NPS 11.1.2.x and later. 
 
 ## Installation
 To install nzpy using pip type:
@@ -267,7 +267,7 @@ This package returns the following types for values from the IBM Netezza backend
   returned as string
 - numeric and geometry are returned as string
 - the boolean type is returned as bool
-
+- JSON, JSONB and JSONPATH datatypes is returned as string
 
 ## Parameter Style
 nzpy do not support all the DB-API parameter styles. It only supports qmark style. Here’s an example of using the 'qmark' parameter style:
@@ -290,6 +290,7 @@ cursor.execute("create external table et1 'C:\\et1.txt' using ( remotesource 'py
 - SSL/TLSv1.2 crypto support
 - Transaction support: begin, rollback, commit
 - Full support for all IBM Netezza data types
+- Support JSON, JSONB and JSONPATH datatypes
 - Full DDL, DML query syntax support for IBM Netezza
 - Full external table support (load and unload)
 - Configurable logging feature

--- a/nzpy/core.py
+++ b/nzpy/core.py
@@ -28,7 +28,6 @@ from ipaddress import (
 from datetime import timezone as Timezone
 import datetime
 import enum
-import pdb
 
 # Copyright (c) 2007-2009, Mathieu Fenniak
 # Copyright (c) The Contributors

--- a/nzpy/core.py
+++ b/nzpy/core.py
@@ -28,6 +28,7 @@ from ipaddress import (
 from datetime import timezone as Timezone
 import datetime
 import enum
+import pdb
 
 # Copyright (c) 2007-2009, Mathieu Fenniak
 # Copyright (c) The Contributors
@@ -1113,12 +1114,29 @@ NzDEPR_Blob = 24            # OBSOLETE 3.0: BLAST Era Large 'binary' Object
 NzTypeNChar = 25
 NzTypeNVarChar = 26
 NzDEPR_NText = 27           # OBSOLETE 3.0: BLAST Era Large 'nchar text' Object
-NzTypeLastEntry = 28        # KEEP THIS ENTRY LAST - used internally to size an array
+#skip 28
+#skip 29
+NzTypeJson = 30
+NzTypeJsonb = 31
+NzTypeJsonpath = 32
+NzTypeLastEntry = 33        # KEEP THIS ENTRY LAST - used internally to size an array
 
 # this is version of nzpy driver
-nzpy_client_version = "11.0.0.0"
+nzpy_client_version = "Release 11.1.0.0"
 
-dataType = {NzTypeChar: "NzTypeChar", NzTypeVarChar: "NzTypeVarChar", NzTypeVarFixedChar: "NzTypeVarFixedChar", NzTypeGeometry: "NzTypeGeometry", NzTypeVarBinary: "NzTypeVarBinary", NzTypeNChar: "NzTypeNChar", NzTypeNVarChar: "NzTypeNVarChar"}
+dataType = {
+            NzTypeChar:         "NzTypeChar",
+            NzTypeVarChar:      "NzTypeVarChar",
+            NzTypeVarFixedChar: "NzTypeVarFixedChar",
+            NzTypeGeometry:     "NzTypeGeometry",
+            NzTypeVarBinary:    "NzTypeVarBinary",
+            NzTypeNChar:        "NzTypeNChar",
+            NzTypeNVarChar:     "NzTypeNVarChar",
+            NzTypeJson:         "NzTypeJson",
+            NzTypeJsonb:        "NzTypeJsonb",
+            NzTypeJsonpath:     "NzTypeJsonpath"
+                
+           }
 
 arr_trans = dict(zip(map(ord, "[] 'u"), list('{}') + [None] * 3))
 
@@ -1768,7 +1786,7 @@ class Connection():
                 self.log.warning("got %d parameters but the statement requires %d", len(args), placeholderCount)
 	
         for arg in args:
-            if isinstance(arg, str) or isinstance(arg, datetime.time) or isinstance(arg, datetime.date) or isinstance(arg, datetime.datetime):
+            if isinstance(arg, str) or isinstance(arg, datetime.time) or isinstance(arg, datetime.date) or isinstance(arg, datetime.datetime) or isinstance(arg, dict):
                 strfmt = "'{}'"                
                 query = query.replace('?', strfmt.format(arg), 1)
             elif isinstance(arg, bytes):
@@ -2033,7 +2051,7 @@ class Connection():
                 memsize = memsize + 1
             if fldtype == NzTypeChar or fldtype == NzTypeVarChar or fldtype == NzTypeVarFixedChar or fldtype == NzTypeGeometry or fldtype == NzTypeVarBinary:
                 memsize = memsize + 1
-            if fldtype == NzTypeNChar or fldtype == NzTypeNVarChar: 
+            if fldtype == NzTypeNChar or fldtype == NzTypeNVarChar or fldtype == NzTypeJson or fldtype == NzTypeJsonb or fldtype == NzTypeJsonpath: 
                 memsize *= 4
                 memsize = memsize + 1 
             if fldtype == NzTypeDate:
@@ -2060,7 +2078,7 @@ class Connection():
                 row.append(value)
                 self.log.debug("field=%d, datatype=%s, value=%s", cur_field+1,dataType[fldtype], value)                
                 
-            if fldtype == NzTypeVarChar or fldtype == NzTypeVarFixedChar or fldtype == NzTypeGeometry or fldtype == NzTypeVarBinary:
+            if fldtype == NzTypeVarChar or fldtype == NzTypeVarFixedChar or fldtype == NzTypeGeometry or fldtype == NzTypeVarBinary or fldtype == NzTypeJson or fldtype == NzTypeJsonb or fldtype == NzTypeJsonpath:
                 cursize  = int.from_bytes(fieldDataP[0:2], 'little') - 2
                 value = str(fieldDataP[2:cursize+2], self._char_varchar_encoding)
                 row.append(value)

--- a/tests/test_typeconversion.py
+++ b/tests/test_typeconversion.py
@@ -309,6 +309,43 @@ def test_array_inspect(con):
     con.array_inspect([[1], [2], [3]])
     con.array_inspect([[[1]], [[2]], [[3]]])
 
+def test_json_roundtrip(cursor):
+    val = {'name': 'Apollo 11 Cave', 'zebra': True, 'age': 26.003}
+    retval = tuple(cursor.execute("SELECT ?", (json.dumps(val),)))
+    assert retval[0][0] == '{"name": "Apollo 11 Cave", "zebra": true, "age": 26.003}'
+
+
+def test_jsonb_roundtrip(cursor):
+    val = {'name': 'Apollo 11 Cave', 'zebra': True, 'age': 26.003}
+    cursor.execute("SELECT cast(? as jsonb)", (json.dumps(val),))
+    retval = cursor.fetchall()
+    assert retval[0][0] == '{"age": 26.003, "name": "Apollo 11 Cave", "zebra": true}'
+
+
+def test_json_access_object(cursor):
+    val = {'name': 'Apollo 11 Cave', 'zebra': True, 'age': 26.003}
+    cursor.execute("SELECT cast(? as json) -> ?", (json.dumps(val), 'name'))
+    retval = cursor.fetchall()
+    assert retval[0][0] == '"Apollo 11 Cave"'
+
+def test_jsonb_access_object(cursor):
+    val = {'name': 'Apollo 11 Cave', 'zebra': True, 'age': 26.003}
+    cursor.execute("SELECT cast(? as jsonb) -> ?", (json.dumps(val), 'name'))
+    retval = cursor.fetchall()
+    assert retval[0][0] == '"Apollo 11 Cave"'
+
+def test_json_access_array(cursor):
+    val = [-1, -2, -3, -4, -5]
+    cursor.execute("SELECT cast(? as json) -> ?", (json.dumps(val), 2))
+    retval = cursor.fetchall()
+    assert retval[0][0] == '-3'
+
+
+def test_jsonb_access_array(cursor):
+    val = [-1, -2, -3, -4, -5]
+    cursor.execute("SELECT cast(? as jsonb) -> ?", (json.dumps(val), 2))
+    retval = cursor.fetchall()
+    assert retval[0][0] == '-3'
 
 '''
 def test_float_plus_infinity_roundtrip(cursor):
@@ -709,48 +746,6 @@ def test_hstore_roundtrip(cursor):
     val = '"a"=>"1"'
     retval = tuple(cursor.execute("SELECT cast(? as hstore)", (val,)))
     assert retval[0][0] == val
-
-
-def test_json_roundtrip(cursor):
-    val = {'name': 'Apollo 11 Cave', 'zebra': True, 'age': 26.003}
-    retval = tuple(cursor.execute("SELECT ?", (nzpy.PGJson(val),)))
-    assert retval[0][0] == val
-
-
-def test_jsonb_roundtrip(cursor):
-    val = {'name': 'Apollo 11 Cave', 'zebra': True, 'age': 26.003}
-    cursor.execute("SELECT cast(? as jsonb)", (json.dumps(val),))
-    retval = cursor.fetchall()
-    assert retval[0][0] == val
-
-
-def test_json_access_object(cursor):
-    val = {'name': 'Apollo 11 Cave', 'zebra': True, 'age': 26.003}
-    cursor.execute("SELECT cast(? as json) -> ?", (json.dumps(val), 'name'))
-    retval = cursor.fetchall()
-    assert retval[0][0] == 'Apollo 11 Cave'
-
-
-def test_jsonb_access_object(cursor):
-    val = {'name': 'Apollo 11 Cave', 'zebra': True, 'age': 26.003}
-    cursor.execute("SELECT cast(? as jsonb) -> ?", (json.dumps(val), 'name'))
-    retval = cursor.fetchall()
-    assert retval[0][0] == 'Apollo 11 Cave'
-
-
-def test_json_access_array(cursor):
-    val = [-1, -2, -3, -4, -5]
-    cursor.execute("SELECT cast(? as json) -> ?", (json.dumps(val), 2))
-    retval = cursor.fetchall()
-    assert retval[0][0] == -3
-
-
-def test_jsonb_access_array(cursor):
-    val = [-1, -2, -3, -4, -5]
-    cursor.execute("SELECT cast(? as jsonb) -> ?", (json.dumps(val), 2))
-    retval = cursor.fetchall()
-    assert retval[0][0] == -3
-
 
 def test_jsonb_access_path(cursor):
     j = {


### PR DESCRIPTION
JIRA: https://github.com/IBM/nzpy/issues/42

Problem: Two new datatypes are introduced in NPS: JSON and JSONB. The support of these two datatypes on the server-side requires some changes on the client-side so it can retrieve JSON/JSONB data from the server. 

Solution:

1. Enabling nzpy client to send its client version string 'Release 11.1.0.0' to the server at the beginning of each session, which tells the server that nzpy client is capable of handling JSON/ JSONB data. Notice: the client version string must start with a string, such as 'Release', in order for the server to properly parse it.
2. Mapping JSON/JSONB data to string type in nzpy, which can be handled in a similar fashion as NVARCHAR data in nzpy.

Testing: Ran an application which fetches JSON and JSONB datatypes. Results attached in JIRA.
Ran test suite 'pytest -vv tests/test_typeconversion.py'

