### PR TITLE
Add a way to pass pgoptions when establishing the connection

### DIFF
--- a/nzpy/__init__.py
+++ b/nzpy/__init__.py
@@ -43,11 +43,11 @@ __author__ = "Mathieu Fenniak"
 def connect(
         user, host='localhost', unix_sock=None, port=5432, database=None, 
         password=None, ssl=None, securityLevel= 0, timeout=None, application_name=None,
-        max_prepared_statements=1000, datestyle = 'ISO', logLevel = 0, tcp_keepalive=True, char_varchar_encoding='latin', logOptions=LogOptions.Inherit):
+        max_prepared_statements=1000, datestyle = 'ISO', logLevel = 0, tcp_keepalive=True, char_varchar_encoding='latin', logOptions=LogOptions.Inherit, pgOptions=None):
 
     return Connection(
         user, host, unix_sock, port, database, password, ssl, securityLevel, timeout,
-        application_name, max_prepared_statements, datestyle, logLevel, tcp_keepalive,char_varchar_encoding, logOptions)
+        application_name, max_prepared_statements, datestyle, logLevel, tcp_keepalive,char_varchar_encoding, logOptions, pgOptions)
 
 
 apilevel = "2.0"

--- a/nzpy/core.py
+++ b/nzpy/core.py
@@ -1168,7 +1168,7 @@ class Connection():
 
     def __init__(
             self, user, host, unix_sock, port, database, password, ssl,
-            securityLevel, timeout, application_name, max_prepared_statements, datestyle, logLevel, tcp_keepalive, char_varchar_encoding, logOptions=LogOptions.Inherit):
+            securityLevel, timeout, application_name, max_prepared_statements, datestyle, logLevel, tcp_keepalive, char_varchar_encoding, logOptions=LogOptions.Inherit, pgOptions=None):
         self._char_varchar_encoding = char_varchar_encoding
         self._client_encoding = "utf8"
         self._commands_with_count = (
@@ -1528,7 +1528,7 @@ class Connection():
             COPY_OUT_RESPONSE: self.handle_COPY_OUT_RESPONSE}
         
         hs = handshake.Handshake(self._usock, self._sock, ssl, self.log)
-        response = hs.startup(database, securityLevel, user, password)
+        response = hs.startup(database, securityLevel, user, password, pgOptions)
         
         if response is not False: 
             self._flush = response.flush


### PR DESCRIPTION
Add code for passing pgoptions when establishing a database connection

Testing:

- Tried to do testing with python2, but there seems to be sytax errors unrelated to my changes
- Tested with python3...one failed test, but seems unrelated 'FAILED test_typeconversion.py::test_xml_roundtrip - nzpy.core.ProgrammingError: ERROR:  Function 'XMLPARSE(UNKNOWN)' does not exist'
- Used interactive python shell to ensure that my pgoption was passed, and the effect was correctly taken by the database