### PR TITLE
Cursor description should return tuple

### DIFF
--- a/nzpy/core.py
+++ b/nzpy/core.py
@@ -805,8 +805,8 @@ class Cursor():
         columns = []
         for col in row_desc:
             columns.append(
-                (col["name"], col["type_oid"], None, None, None, None, None))
-        return columns
+                (col["name"].decode(), col["type_oid"]))
+        return tuple(columns)
 
     ##
     # Executes a database operation.  Parameters may be provided as a sequence


### PR DESCRIPTION
https://github.com/IBM/nzpy/issues/49

To work with Apache Superset, nzpy cursor description should return mandatory attributes in a tuple.

Test:
Tested with different superset charts/graphs. 
