### PR TITLE
clear cursor before execute

### DIFF
--- a/nzpy/core.py
+++ b/nzpy/core.py
@@ -842,6 +842,7 @@ class Cursor():
         """
         try:
             self.stream = stream
+            self.clear()
 
             if not self._c.in_transaction and not self._c.autocommit:
                self._c.execute(self, "begin", None)
@@ -870,6 +871,7 @@ class Cursor():
             in the sequence should be sequences or mappings of parameters, the
             same as the args argument of the :meth:`execute` method.
         """
+        self.clear()
         rowcounts = []
         for parameters in param_sets:
             self.execute(operation, parameters)
@@ -976,6 +978,12 @@ class Cursor():
             else:
                 raise StopIteration()
 
+    def clear(self):
+        self.arraysize = 1
+        self.ps = None
+        self._row_count = -1
+        self._cached_rows.clear()
+        self.notices.clear()
 
 # Message codes
 NOTICE_RESPONSE = b"N"


### PR DESCRIPTION
Fixes https://github.com/IBM/nzpy/issues/54

Test:
before: fetchone() would return next of unconsumed resultset of prior query.
now:
```
>>> with nzpy.connect(user="admin", password="password", host="localhost", port=5480, database="db1") as conn:
...     with conn.cursor() as curs:
...             curs.execute("Select * from t1")
...             curs.description
...             curs.fetchone()
...             curs.execute("select * from _v_Database")
...             curs.description
...             curs.fetchone()
... 
<nzpy.core.Cursor object at 0x7ff728466da0>
(('OBJID', 23), ('OBJNAME', 2530))
[5006, '_T_OBJECT']
<nzpy.core.Cursor object at 0x7ff728466da0>
(('OBJID', 26), ('DATABASE', 19), ('OWNER', 19), ('CREATEDATE', 702), ('DB_CHARSET', 19), ('DB_COLLATION', 19), ('DBCHARSET', 26), ('DBCOLLATION', 26), ('DBOWNERID', 26), ('DBLOCKPID', 23), ('DBSTATUS', 2530), ('BACKUPGROUP', 19), ('OBJDELIM', 16), ('DBCOLLECTHISTORY', 16), ('ENCODING', 23), ('DEFSCHEMAID', 26), ('DEFSCHEMA', 19), ('NCHARENCODING', 23), ('NCHARSET', 1043), ('DBTRACKCHANGES', 2500), ('DATAVERRETNTIME', 21), ('GROOMBACKUPSET', 1043), ('DATAVERRETNLOWERBOUND', 1184))
[200212, 'DB1', 'ADMIN', '2021-08-24 03:40:36', 'LATIN9', 'BINARY', 4960, 4970, 1000, 0, None, None, False, True, 0, 200211, 'ADMIN', 0, 'UTF8', '1', 0, '0', None]
>>> 
```