### PR TITLE
Add a feature to run multiple queries written in a single query statement.

### DIFF
--- a/nzpy/core.py
+++ b/nzpy/core.py
@@ -878,7 +878,7 @@ class Cursor():
             making up a row.
         """
         try:
-            return tuple(self)
+            return list(self) if self.connection.multiple_flag else tuple(self)
         except TypeError:
             raise ProgrammingError("attempting to use unexecuted cursor")
 
@@ -1148,7 +1148,7 @@ class Connection():
         self.parameter_statuses = deque(maxlen=100)
         self.max_prepared_statements = int(max_prepared_statements)
 
-        self.query_data = []
+        self.query_data = ()
         self.multiple_flag = False
 
         # honor logging.* log level constants if specified
@@ -1867,7 +1867,7 @@ class Connection():
                 if self.multiple_flag:
                     if len(self.query_data) != 0:
                         cursor._cached_rows.append(self.query_data)
-                    self.query_data = []
+                    self.query_data = ()
                 continue
             if response == READY_FOR_QUERY:
                 return True
@@ -2274,7 +2274,7 @@ class Connection():
             cur_field += 1
             field_lf += 1
         if self.multiple_flag:
-            self.query_data.append(row)
+            self.query_data += (row,)
         else:
             cursor._cached_rows.append(row)
 
@@ -2563,7 +2563,7 @@ class Connection():
                 row.append(func(data, data_idx, vlen - 4))
                 data_idx += vlen - 4
         if self.multiple_flag:
-            self.query_data.append(row)
+            self.query_data += (row,)
         else:
             cursor._cached_rows.append(row)
 

--- a/tests/test_multiple_queries.py
+++ b/tests/test_multiple_queries.py
@@ -1,0 +1,45 @@
+import nzpy
+import unittest
+import random
+
+class TestVectorDml(unittest.TestCase):
+    connection = None
+
+    def setUp(self):
+        if self.connection is None:
+            self.connection = nzpy.connect(user="user", unix_sock='unix_sock_file_dir', database='dbname', logOptions=nzpy.LogOptions.Disabled)
+
+    def tearDown(self):
+        self.connection.close()
+
+    def test_simple_dml(self):
+        '''Test various DML operations (INSERT, UPDATE, DELETE, SELECT).
+        Using a non-VECTOR column as reference'''
+        with self.connection.cursor() as cur:
+            try:
+                cur.execute("""
+                drop table t1 if exists;
+                create table t1 (v1 int);
+                insert into t1 select 111 union select 222;
+                select * from t1;
+
+                alter table t1 ADD COLUMN v2 VARCHAR(50);
+                update t1 set v2='aaa' where v1 =111;
+                update t1 set v2='bbb' where v1 =222;
+                select * from t1;
+
+                drop table names if exists;
+                create table names (id int, first_name varchar(10),last_name varchar(10));
+                insert into names select 1, 'John', 'Doe' union select 2, 'Mark', 'Powell';
+                select * from names;
+                """)
+
+                expected_result_set = [
+                    ([111], [222]),
+                    ([111, 'aaa'], [222, 'bbb']),
+                    ([1, 'John', 'Doe'], [2, 'Mark', 'Powell'])
+                    ]
+                self.assertEqual(cur.fetchall(), expected_result_set)
+
+            finally:
+                pass


### PR DESCRIPTION
Problem:
If any query was executed using nzpy which consists of multiple queries in a single statement , then the result fetched was not giving proper results.

Solution:
Updated the core.py to store to store the results of different queries in separate tuples and return them as list of tuples where each tuple is a result set of a single query.

Testing:
Run the following command to test :
`python3 -m pytest -xv tests/test_multiple_queries.py`