### PR TITLE
Fix for deprecation warnings

### DIFF
--- a/nzpy/handshake.py
+++ b/nzpy/handshake.py
@@ -243,7 +243,7 @@ class Handshake():
     def conn_secure_session(self, securityLevel):
         information = HSV2_SSL_NEGOTIATE
         currSecLevel = securityLevel
-
+        ssl_context = None
         while information != 0:
             if information == HSV2_SSL_NEGOTIATE:
                 # SecurityLevel meaning
@@ -266,7 +266,7 @@ class Handshake():
 
             if information == HSV2_SSL_CONNECT:
                 try:
-                    self._usock = ssl.SSLContext().wrap_socket(self._usock)
+                    self._usock = ssl_context.wrap_socket(self._usock)
                     self._sock = self._usock.makefile(mode="rwb")
                     self.log.info("Secured Connect Success")
                 except ssl.SSLError:


### PR DESCRIPTION
Problem:
The code in handshake.py for creating sslcontext was deprecated.

Solution:
Updated the code to remove deprecation warnings.

Test:
Create a secure ssl connection to nps using nzpy by providing the cacert.pem file .

Before fix
```
python3 test.py
/Users/ayush/Desktop/teempnapy/venv/lib/python3.12/site-packages/nzpy/handshake.py:269: DeprecationWarning: ssl.SSLContext() without protocol argument is deprecated.
  self._usock = ssl.SSLContext().wrap_socket(self._usock)
/Users/ayush/Desktop/teempnapy/venv/lib/python3.12/site-packages/nzpy/handshake.py:269: DeprecationWarning: ssl.PROTOCOL_TLS is deprecated
  self._usock = ssl.SSLContext().wrap_socket(self._usock)
Connection to nzpy successful
```

After Fix
```
python3 test.py
Connection to nzpy successful
```
