### PR TITLE
Enable nzpy server CA certification mandatory.

### DIFF
--- a/nzpy/__init__.py
+++ b/nzpy/__init__.py
@@ -51,13 +51,13 @@ def connect(user, host='localhost', unix_sock=None, port=5432, database=None,
             application_name=None, max_prepared_statements=1000,
             datestyle='ISO', logLevel=0, tcp_keepalive=True,
             char_varchar_encoding='latin', logOptions=LogOptions.Inherit,
-            pgOptions=None):
+            pgOptions=None, skipCertVerification=False):
 
     return Connection(user, host, unix_sock, port, database, password, ssl,
                       securityLevel, timeout, application_name,
                       max_prepared_statements, datestyle, logLevel,
                       tcp_keepalive, char_varchar_encoding,
-                      logOptions, pgOptions)
+                      logOptions, pgOptions, skipCertVerification)
 
 
 apilevel = "2.0"

--- a/nzpy/core.py
+++ b/nzpy/core.py
@@ -1138,7 +1138,7 @@ class Connection():
             securityLevel, timeout, application_name,
             max_prepared_statements, datestyle, logLevel, tcp_keepalive,
             char_varchar_encoding, logOptions=LogOptions.Inherit,
-            pgOptions=None):
+            pgOptions=None, skipCertVerification=False):
         self._char_varchar_encoding = char_varchar_encoding
         self._client_encoding = "utf8"
         self._commands_with_count = (
@@ -1518,7 +1518,7 @@ class Connection():
 
         hs = handshake.Handshake(self._usock, self._sock, ssl, self.log)
         response = hs.startup(database, securityLevel,
-                              user, password, pgOptions)
+                              user, password, pgOptions, skipCertVerification)
 
         if response is not False:
             self._flush = response.flush

--- a/nzpy/handshake.py
+++ b/nzpy/handshake.py
@@ -78,7 +78,7 @@ class Handshake():
         self.guardium_clientHostName = gethostname()
         self.guardium_applName = path.basename(argv[0])
 
-    def startup(self, database, securityLevel, user, password, pgOptions):
+    def startup(self, database, securityLevel, user, password, pgOptions, skipCertVerification):
         #  Negotiate the handshake version (connection protocol)
         if not self.conn_handshake_negotiate(self._sock.write, self._sock.read,
                                              self._sock.flush, self._hsVersion,
@@ -91,7 +91,7 @@ class Handshake():
                                              self._sock.flush, database,
                                              securityLevel, self._hsVersion,
                                              self._protocol1, self._protocol2,
-                                             user, pgOptions):
+                                             user, pgOptions, skipCertVerification):
             self.log.warning("Error in conn_send_handshake_info")
             return False
 
@@ -165,7 +165,7 @@ class Handshake():
     def conn_send_handshake_info(self, _write, _read, _flush, _database,
                                  securityLevel, _hsVersion,
                                  _protocol1, _protocol2,
-                                 user, pgOptions):
+                                 user, pgOptions, skipCertVerification):
         #  We need database information at the backend in order to
         #  select security restrictions. So always send the database first
         if not self.conn_send_database(_write, _read, _flush, _database):
@@ -173,7 +173,7 @@ class Handshake():
 
         #  If the backend supports security features and if the driver
         #  requires secured session, negotiate security requirements now
-        if not self.conn_secure_session(securityLevel):
+        if not self.conn_secure_session(securityLevel, skipCertVerification):
             return False
 
         if not self.conn_set_next_dataprotocol(self._protocol1,
@@ -240,7 +240,7 @@ class Handshake():
                        self._protocol1, self._protocol2)
         return True
 
-    def conn_secure_session(self, securityLevel):
+    def conn_secure_session(self, securityLevel, skipCertVerification):
         information = HSV2_SSL_NEGOTIATE
         currSecLevel = securityLevel
         ssl_context = None
@@ -294,8 +294,11 @@ class Handshake():
                         ssl_context = ssl.create_default_context(
                             cafile=ca_certs)
                         ssl_context.check_hostname = False
-                        if ca_certs is None:
+                        if ca_certs is None or ca_certs == "":
                             ssl_context.verify_mode = ssl.CERT_NONE
+                            if not skipCertVerification:
+                                self.log.warning("Could not load ca certificate %s : too long , possibly corrupted or file not found",ca_certs)
+                                return False
                         else:
                             ssl_context.verify_mode = ssl.CERT_REQUIRED
 


### PR DESCRIPTION
Testing - 
```
conn = nzpy.connect(
            user="admin",
            password="password",
            host="simcon21.fyre.ibm.com",
            port=5480,
            database="bnrdb",
            securityLevel=2,
            logLevel=0,
            skipCertVerification=False,
            ssl={}
        )

[nz@mp1 nzpy]$ python3 sample2.py
Testing Security Level 2 (Preferred Secured session)
Could not load ca certificate None : too long , possibly corrupted or file not found
Error in conn_send_handshake_info
Connection failed for security level 2: Error in handshake
```