### PR TITLE
Fix: External table unload overwrites large datasets

### DIFF
--- a/nzpy/core.py
+++ b/nzpy/core.py
@@ -2333,7 +2333,7 @@ class Connection():
                 try:
                     blockBuffer = str(self._read(numBytes),
                                       self._client_encoding)
-                    fh = open(fname, "w+")
+                    fh = open(fname, "a")
                     fh.write(blockBuffer)
                     self.log.info("Successfully written data into file")
                 except Exception:


### PR DESCRIPTION
Change file write mode from 'w+' to 'a' in receiveAndWriteDatatoExternal() to append data chunks instead of overwriting. This prevents data loss when unloading datasets larger than the SocketBufSize option.

Previously, each data chunk would overwrite the target file, resulting in only the last chunk being preserved. With append mode, all chunks are correctly written to the output file.

Fixes: External table unload data truncation for large datasets

Fixes #90

Signed-off-by: djfrancesco <francois.pacull@architecture-performance.fr>
