### PR TITLE
Fix UTF-8 encoding issue on Windows for external tables

### DIFF
--- a/nzpy/core.py
+++ b/nzpy/core.py
@@ -2406,7 +2406,7 @@ class Connection():
                       blockSize, hostversion)
 
         try:
-            filehandle = open(filename, 'r')
+            filehandle = open(filename, 'r', encoding='utf-8')
             self.log.info("Successfully opened External"
                           " file to read:%s", filename)
             while True:


### PR DESCRIPTION
## Fix for UTF-8 Encoding Issue on Windows (Issue #92)

### Problem
When using external tables to read UTF-8 encoded CSV files on Windows, users encountered "Error opening file" because the Python code was opening files with the default Windows encoding (cp1252) instead of UTF-8.

### Root Cause
The issue occurs in `nzpy/core.py` in the `xferTable()` function where:
- Files were opened with `open(filename, 'r')` - using Windows default encoding (cp1252)
- But Netezza external tables only support **Latin9 and UTF-8** encodings, not Windows-1252 ([link](https://www.ibm.com/docs/en/netezza?topic=details-encoding-option))
- This encoding mismatch could also lead decoding errors 

### Solution
Changed the file opening to explicitly specify UTF-8 encoding:
```python
# Before (problematic on Windows)
filehandle = open(filename, 'r')

# After (correctly handles UTF-8)
filehandle = open(filename, 'r', encoding='utf-8')