### PR TITLE
added skipverification flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,33 +198,66 @@ This is `nzpy.LogOptions.Disabled` option
 You can configure logLevel as per your requirement. Any levels in standard `logging` module can be used. The default is `logging.INFO`
 
 
-## SecurityLevel 
-The level of security (SSL/TLS) that the driver uses for the connection to the data store. 
-```
-onlyUnSecured: The driver does not use SSL. 
-preferredUnSecured: If the server provides a choice, the driver does not use SSL. 
-preferredSecured: If the server provides a choice, the driver uses SSL. 
-onlySecured: The driver does not connect unless an SSL connection is available. 
-```
-Similarly, IBM Netezza server has above securityLevel. 
+## SecurityLevel
+The level of security (SSL/TLS) that the driver uses for the connection to the data store.
 
-Cases which would fail :
-- Client tries to connect with 'Only secured' or 'Preferred secured' mode while server is 'Only Unsecured' mode
-- Client tries to connect with 'Only secured' or 'Preferred secured' mode while server is 'Preferred Unsecured' mode
-- Client tries to connect with 'Only Unsecured' or 'Preferred Unsecured' mode while server is 'Only Secured' mode
-- Client tries to connect with 'Only Unsecured' or 'Preferred Unsecured' mode while server is 'Preferred Secured' mode 
+| Value | Name | Description |
+|-------|------|-------------|
+| `0` | Preferred Unsecured | If the server provides a choice, the driver does not use SSL. |
+| `1` | Only Unsecured | The driver does not use SSL. Fails if the server requires SSL. |
+| `2` | Preferred Secured | If the server provides a choice, the driver uses SSL. |
+| `3` | Only Secured | The driver does not connect unless an SSL connection is available. |
 
-Below is an example how you could pass securityLevel and ca certificate in connection string:
+Similarly, the IBM Netezza server has its own securityLevel setting. The client and server levels must be compatible.
+
+**Cases that will fail:**
+- Client uses `Only Secured` (3) or `Preferred Secured` (2) while server is `Only Unsecured`
+- Client uses `Only Secured` (3) or `Preferred Secured` (2) while server is `Preferred Unsecured`
+- Client uses `Only Unsecured` (1) or `Preferred Unsecured` (0) while server is `Only Secured`
+- Client uses `Only Unsecured` (1) or `Preferred Unsecured` (0) while server is `Preferred Secured`
+
+Below is an example of how to pass `securityLevel` and a CA certificate in the connection string:
+```python
+conn = nzpy.connect(user="admin", password="password", host='localhost', port=5480,
+                    database="db1", securityLevel=3, logLevel=0,
+                    ssl={'ca_certs': '/nz/cacert.pem'})
 ```
-conn = nzpy.connect(user="admin", password="password",host='localhost', port=5480, database="db1", securityLevel=3, logLevel=0, ssl = {'ca_certs' : '/nz/cacert.pem'})
+
+## skipCertVerification
+Controls whether the driver verifies the server's SSL certificate when an SSL connection is established.
+
+The default value is derived automatically from `securityLevel` when not explicitly provided:
+
+| `securityLevel` | Default `skipCertVerification` | Reason |
+|-----------------|-------------------------------|--------|
+| `0` (Preferred Unsecured) | `True` | No SSL expected — cert check is irrelevant |
+| `1` (Only Unsecured) | `True` | No SSL expected — cert check is irrelevant |
+| `2` (Preferred Secured) | `False` | SSL intended — server certificate is verified |
+| `3` (Only Secured) | `False` | SSL required — server certificate is verified |
+
+You can always override the default explicitly:
+
+```python
+# securityLevel=3 but skip cert verification (e.g. self-signed cert in dev)
+conn = nzpy.connect(user="admin", password="password", host='localhost', port=5480,
+                    database="db1", securityLevel=3, ssl={},
+                    skipCertVerification=True)
+
+# securityLevel=3 with a CA cert — verify the server certificate (default for level 2/3)
+conn = nzpy.connect(user="admin", password="password", host='localhost', port=5480,
+                    database="db1", securityLevel=3,
+                    ssl={'ca_certs': '/nz/cacert.pem'})
+
+# securityLevel=3 with empty/missing CA cert and skipCertVerification=False (default)
+# — this will FAIL with a warning, as no valid certificate was supplied
+conn = nzpy.connect(user="admin", password="password", host='localhost', port=5480,
+                    database="db1", securityLevel=3, ssl={})
 ```
-Below are the securityLevel you can pass in connection string : 
-```
-0: Preferred Unsecured session
-1: Only Unsecured session
-2: Preferred Secured session
-3: Only Secured session
-```
+
+**Note:** When `skipCertVerification=False` (the default for `securityLevel` 2 and 3) and no valid
+`ca_certs` path is supplied via the `ssl` parameter, the connection will be rejected with a
+warning log message. Supply a valid CA certificate file or explicitly pass `skipCertVerification=True`
+to allow connections without certificate verification.
 
 ## Connection String 
 Use connect to create a database connection with connection parameters: 
@@ -234,15 +267,26 @@ conn = nzpy.connect(user="admin", password="password",host='localhost', port=548
 The above example opens a database handle on localhost. nzpy driver should connect on port 5480(postgres port). The user is admin, password is password, database is db1 and the location of the ca certificate file is /nz/cacert.pem with securityLevel as 'Only Secured session' 
 
 **Connection Parameters**
-When establishing a connection using nzgo you are expected to supply a connection string containing zero or more parameters. Below are subset of the connection parameters supported by nzgo. 
-The following special connection parameters are supported: 
-- database - The name of the database to connect to
-- user - The user to sign in as
-- password - The user's password
-- host - The host to connect to. Values that start with / are for unix domain sockets. (default is localhost)
-- port - The port to bind to. 
-- securityLevel - Whether or not to use SSL (default is 0)
-- ssl - Python dictionary containing location of the root certificate file. The file must contain PEM encoded data.
+When establishing a connection using nzpy you are expected to supply a connection string containing zero or more parameters. The following connection parameters are supported:
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `user` | str | *(required)* | The user to sign in as |
+| `password` | str | `None` | The user's password |
+| `host` | str | `'localhost'` | The host to connect to. Values starting with `/` are unix domain sockets |
+| `port` | int | `5432` | The port to connect to |
+| `database` | str | `None` | The name of the database to connect to |
+| `securityLevel` | int | `0` | SSL/TLS mode: `0` Preferred Unsecured, `1` Only Unsecured, `2` Preferred Secured, `3` Only Secured |
+| `ssl` | dict | `None` | Dictionary with optional key `ca_certs` pointing to a PEM-encoded CA certificate file |
+| `skipCertVerification` | bool | auto | Whether to skip SSL certificate verification. Defaults to `True` for `securityLevel` 0/1, `False` for 2/3. See [skipCertVerification](#skipcertverification) |
+| `timeout` | int | `None` | Socket connection timeout in seconds |
+| `logLevel` | int | `0` | Logging verbosity. Accepts `logging.*` constants or `0`=DEBUG, `1`=INFO, `2`=WARNING |
+| `logOptions` | LogOptions | `LogOptions.Inherit` | Logging destination flags. See [Logging](#logging) |
+| `char_varchar_encoding` | str | `'latin'` | Encoding for char/varchar columns |
+| `application_name` | str | `None` | Application name reported to the server |
+| `max_prepared_statements` | int | `1000` | Maximum number of prepared statements to cache |
+| `tcp_keepalive` | bool | `True` | Whether to enable TCP keepalive on the connection socket |
+| `pgOptions` | str | `None` | Additional PostgreSQL options string |
 
 
 ## Transactions 

--- a/README.md
+++ b/README.md
@@ -210,11 +210,11 @@ The level of security (SSL/TLS) that the driver uses for the connection to the d
 
 Similarly, the IBM Netezza server has its own securityLevel setting. The client and server levels must be compatible.
 
-**Cases that will fail:**
-- Client uses `Only Secured` (3) or `Preferred Secured` (2) while server is `Only Unsecured`
-- Client uses `Only Secured` (3) or `Preferred Secured` (2) while server is `Preferred Unsecured`
-- Client uses `Only Unsecured` (1) or `Preferred Unsecured` (0) while server is `Only Secured`
-- Client uses `Only Unsecured` (1) or `Preferred Unsecured` (0) while server is `Preferred Secured`
+**Cases that will fail (guaranteed hard failures):**
+- Client uses `Only Secured` (3) while server is `Only Unsecured` or `Preferred Unsecured`
+- Client uses `Only Unsecured` (1) while server is `Only Secured`
+
+**Note on Preferred modes:** `Preferred Secured` (2) and `Preferred Unsecured` (0) are negotiated — the driver attempts the preferred mode and falls back if the server does not support it. These are not guaranteed failures in mixed configurations.
 
 Below is an example of how to pass `securityLevel` and a CA certificate in the connection string:
 ```python
@@ -264,7 +264,7 @@ Use connect to create a database connection with connection parameters:
 ```
 conn = nzpy.connect(user="admin", password="password",host='localhost', port=5480, database="db1", securityLevel=3, logLevel=0, ssl = {'ca_certs' : '/nz/cacert.pem'})
 ```
-The above example opens a database handle on localhost. nzpy driver should connect on port 5480(postgres port). The user is admin, password is password, database is db1 and the location of the ca certificate file is /nz/cacert.pem with securityLevel as 'Only Secured session' 
+The above example opens a database handle on localhost. IBM Netezza listens on port 5480 by default (note: the nzpy `port` parameter defaults to 5432, so always specify the port explicitly for Netezza). The user is admin, password is password, database is db1, the CA certificate is at /nz/cacert.pem, and securityLevel is set to 'Only Secured session'.
 
 **Connection Parameters**
 When establishing a connection using nzpy you are expected to supply a connection string containing zero or more parameters. The following connection parameters are supported:

--- a/nzpy/__init__.py
+++ b/nzpy/__init__.py
@@ -51,13 +51,13 @@ def connect(user, host='localhost', unix_sock=None, port=5432, database=None,
             application_name=None, max_prepared_statements=1000,
             datestyle='ISO', logLevel=0, tcp_keepalive=True,
             char_varchar_encoding='latin', logOptions=LogOptions.Inherit,
-            pgOptions=None):
+            pgOptions=None, skipCertVerification=False):
 
     return Connection(user, host, unix_sock, port, database, password, ssl,
                       securityLevel, timeout, application_name,
                       max_prepared_statements, datestyle, logLevel,
                       tcp_keepalive, char_varchar_encoding,
-                      logOptions, pgOptions)
+                      logOptions, pgOptions, skipCertVerification)
 
 
 apilevel = "2.0"

--- a/nzpy/__init__.py
+++ b/nzpy/__init__.py
@@ -51,7 +51,14 @@ def connect(user, host='localhost', unix_sock=None, port=5432, database=None,
             application_name=None, max_prepared_statements=1000,
             datestyle='ISO', logLevel=0, tcp_keepalive=True,
             char_varchar_encoding='latin', logOptions=LogOptions.Inherit,
-            pgOptions=None, skipCertVerification=False):
+            pgOptions=None, skipCertVerification=None):
+
+    # Resolve skipCertVerification default based on securityLevel when not
+    # explicitly provided by the caller:
+    #   securityLevel 2 (Preferred Secured) or 3 (Only Secured)  → verify cert
+    #   securityLevel 0 (Preferred Unsecured) or 1 (Only Unsecured) → skip (irrelevant)
+    if skipCertVerification is None:
+        skipCertVerification = securityLevel not in (2, 3)
 
     return Connection(user, host, unix_sock, port, database, password, ssl,
                       securityLevel, timeout, application_name,

--- a/nzpy/core.py
+++ b/nzpy/core.py
@@ -1142,7 +1142,7 @@ class Connection():
             securityLevel, timeout, application_name,
             max_prepared_statements, datestyle, logLevel, tcp_keepalive,
             char_varchar_encoding, logOptions=LogOptions.Inherit,
-            pgOptions=None):
+            pgOptions=None, skipCertVerification=False):
         self._char_varchar_encoding = char_varchar_encoding
         self._client_encoding = "utf8"
         self._commands_with_count = (
@@ -1518,7 +1518,7 @@ class Connection():
 
         hs = handshake.Handshake(self._usock, self._sock, ssl, self.log)
         response = hs.startup(database, securityLevel,
-                              user, password, pgOptions)
+                              user, password, pgOptions, skipCertVerification)
 
         if response is not False:
             self._flush = response.flush

--- a/nzpy/core.py
+++ b/nzpy/core.py
@@ -1142,7 +1142,7 @@ class Connection():
             securityLevel, timeout, application_name,
             max_prepared_statements, datestyle, logLevel, tcp_keepalive,
             char_varchar_encoding, logOptions=LogOptions.Inherit,
-            pgOptions=None, skipCertVerification=False):
+            pgOptions=None, skipCertVerification=None):
         self._char_varchar_encoding = char_varchar_encoding
         self._client_encoding = "utf8"
         self._commands_with_count = (

--- a/nzpy/handshake.py
+++ b/nzpy/handshake.py
@@ -79,7 +79,7 @@ class Handshake():
         self.guardium_applName = path.basename(argv[0])
 
     def startup(self, database, securityLevel, user, password, pgOptions,
-                skipCertVerification=False):
+                skipCertVerification=None):
         #  Negotiate the handshake version (connection protocol)
         if not self.conn_handshake_negotiate(self._sock.write, self._sock.read,
                                              self._sock.flush, self._hsVersion,
@@ -167,7 +167,7 @@ class Handshake():
     def conn_send_handshake_info(self, _write, _read, _flush, _database,
                                  securityLevel, _hsVersion,
                                  _protocol1, _protocol2,
-                                 user, pgOptions, skipCertVerification=False):
+                                 user, pgOptions, skipCertVerification=None):
         #  We need database information at the backend in order to
         #  select security restrictions. So always send the database first
         if not self.conn_send_database(_write, _read, _flush, _database):
@@ -242,7 +242,7 @@ class Handshake():
                        self._protocol1, self._protocol2)
         return True
 
-    def conn_secure_session(self, securityLevel, skipCertVerification=False):
+    def conn_secure_session(self, securityLevel, skipCertVerification=None):
         information = HSV2_SSL_NEGOTIATE
         currSecLevel = securityLevel
         ssl_context = None

--- a/nzpy/handshake.py
+++ b/nzpy/handshake.py
@@ -78,7 +78,8 @@ class Handshake():
         self.guardium_clientHostName = gethostname()
         self.guardium_applName = path.basename(argv[0])
 
-    def startup(self, database, securityLevel, user, password, pgOptions):
+    def startup(self, database, securityLevel, user, password, pgOptions,
+                skipCertVerification=False):
         #  Negotiate the handshake version (connection protocol)
         if not self.conn_handshake_negotiate(self._sock.write, self._sock.read,
                                              self._sock.flush, self._hsVersion,
@@ -91,7 +92,8 @@ class Handshake():
                                              self._sock.flush, database,
                                              securityLevel, self._hsVersion,
                                              self._protocol1, self._protocol2,
-                                             user, pgOptions):
+                                             user, pgOptions,
+                                             skipCertVerification):
             self.log.warning("Error in conn_send_handshake_info")
             return False
 
@@ -165,7 +167,7 @@ class Handshake():
     def conn_send_handshake_info(self, _write, _read, _flush, _database,
                                  securityLevel, _hsVersion,
                                  _protocol1, _protocol2,
-                                 user, pgOptions):
+                                 user, pgOptions, skipCertVerification=False):
         #  We need database information at the backend in order to
         #  select security restrictions. So always send the database first
         if not self.conn_send_database(_write, _read, _flush, _database):
@@ -173,7 +175,7 @@ class Handshake():
 
         #  If the backend supports security features and if the driver
         #  requires secured session, negotiate security requirements now
-        if not self.conn_secure_session(securityLevel):
+        if not self.conn_secure_session(securityLevel, skipCertVerification):
             return False
 
         if not self.conn_set_next_dataprotocol(self._protocol1,
@@ -240,7 +242,7 @@ class Handshake():
                        self._protocol1, self._protocol2)
         return True
 
-    def conn_secure_session(self, securityLevel):
+    def conn_secure_session(self, securityLevel, skipCertVerification=False):
         information = HSV2_SSL_NEGOTIATE
         currSecLevel = securityLevel
         ssl_context = None
@@ -294,8 +296,14 @@ class Handshake():
                         ssl_context = ssl.create_default_context(
                             cafile=ca_certs)
                         ssl_context.check_hostname = False
-                        if ca_certs is None:
+                        if ca_certs is None or ca_certs == "":
                             ssl_context.verify_mode = ssl.CERT_NONE
+                            if not skipCertVerification:
+                                self.log.warning(
+                                    "Could not load ca certificate %s : "
+                                    "too long, possibly corrupted or "
+                                    "file not found", ca_certs)
+                                return False
                         else:
                             ssl_context.verify_mode = ssl.CERT_REQUIRED
 
@@ -325,13 +333,21 @@ class Handshake():
                     return True
 
                 if beresp == b'E':
-                    #  If 'E' is received, because the SSL
-                    #  session establishment failed, and we are
-                    #  requesting preferred secured session,
-                    #  we will have to attempt a non secured session.
-                    #  If this also fails, we have to error out.
-                    #  To achieve this, we now negotiate for
-                    #  essential non-secured session
+                    #  If 'E' is received, because the SSL session
+                    #  establishment failed, and we are requesting preferred
+                    #  secured session, we will have to attempt a non secured
+                    #  session. If this also fails, we have to error out.
+                    #  To achieve this, we now negotiate for essential
+                    #  non-secured session.
+                    #
+                    #  If securityLevel == 1 (Only Unsecured) the server is
+                    #  requiring SSL which we cannot satisfy — fail immediately.
+                    if currSecLevel == 1:
+                        self.log.warning(
+                            "Error: server requires SSL but securityLevel=1 "
+                            "(Only Unsecured) was requested. Use "
+                            "securityLevel=2 or 3 to enable SSL.")
+                        return False
                     self.log.warning("Error: connection failed")
                     return False
 

--- a/nzpy/handshake.py
+++ b/nzpy/handshake.py
@@ -293,19 +293,41 @@ class Handshake():
                         import ssl
 
                         ca_certs = self.ssl_params.get('ca_certs')
-                        ssl_context = ssl.create_default_context(
-                            cafile=ca_certs)
-                        ssl_context.check_hostname = False
+
+                        # Validate ca_certs before attempting to load it.
+                        # An empty/missing path must be handled before calling
+                        # create_default_context, which would raise OSError.
                         if ca_certs is None or ca_certs == "":
-                            ssl_context.verify_mode = ssl.CERT_NONE
                             if not skipCertVerification:
                                 self.log.warning(
-                                    "Could not load ca certificate %s : "
-                                    "too long, possibly corrupted or "
-                                    "file not found", ca_certs)
+                                    "No CA certificate provided. Supply a "
+                                    "valid ca_certs path or set "
+                                    "skipCertVerification=True to allow "
+                                    "connections without certificate "
+                                    "verification.")
                                 return False
+                            ssl_context = ssl.create_default_context()
+                            ssl_context.check_hostname = False
+                            ssl_context.verify_mode = ssl.CERT_NONE
                         else:
-                            ssl_context.verify_mode = ssl.CERT_REQUIRED
+                            try:
+                                ssl_context = ssl.create_default_context(
+                                    cafile=ca_certs)
+                            except OSError as e:
+                                if not skipCertVerification:
+                                    self.log.warning(
+                                        "Could not load CA certificate "
+                                        "'%s': %s. Supply a valid ca_certs "
+                                        "path or set "
+                                        "skipCertVerification=True.",
+                                        ca_certs, e)
+                                    return False
+                                ssl_context = ssl.create_default_context()
+                                ssl_context.check_hostname = False
+                                ssl_context.verify_mode = ssl.CERT_NONE
+                            else:
+                                ssl_context.check_hostname = False
+                                ssl_context.verify_mode = ssl.CERT_REQUIRED
 
                         information = HSV2_SSL_CONNECT
 


### PR DESCRIPTION
Problem :
Need to add a boolean param to enforce validation using cacert

Solution :
Added a boolean flag named skipCertVerification.
By default the value is False for Securitylevel = 2 and 3, which means you need to provide a cacert file to authenticate connection to nps using nzpy.
For  Securitylevel = 0 and 1, the skipCertVerification flag is true, which means if we want to block skip cert verification we need to explicitly set skipverification to false and provide the cacert to authenticate.

When set to True you can skip providing the cacert file and authenticate the connection.

Testing:
Case 1:
When security level=0, no param for skipverification provided, no cacert provided
```
import nzpy
import logging

logging.basicConfig(filename="testnzpy.log")

conn = nzpy.connect(user="admin",
                    password="password",
                    host='abs-nzlite1.fyre.ibm.com',
                    port=5480,
                    database="system",
                    # ssl={'ca_certs':'./cacert.pem'},
                    securityLevel=0,
                    logLevel=logging.DEBUG,
                    logOptions=nzpy.LogOptions.Logfile | nzpy.LogOptions.Inherit,
                    char_varchar_encoding='utf8'
                    )
print(f"Connection created successfully")
```
```      
(local_venv) ayush@Mac nzpy_customer_issue % python3 test.py
Connection created successfully
```

Case 2:
securityLevel = 0
skipCertVerification = False provided explicitly
no cacerts provided
```
import nzpy
import logging

logging.basicConfig(filename="testnzpy.log")

conn = nzpy.connect(user="admin",
                    password="password",
                    host='abs-nzlite1.fyre.ibm.com',
                    port=5480,
                    database="system",
                    # ssl={'ca_certs':'./cacert.pem'},
                    securityLevel=0,
                    logLevel=logging.DEBUG,
                    logOptions=nzpy.LogOptions.Logfile | nzpy.LogOptions.Inherit,
                    char_varchar_encoding='utf8',
                    skipCertVerification = False
                    )
print(f"Connection created successfully")
```
Handshake error
```
(local_venv) ayush@Mac nzpy_customer_issue % python3 test.py
Traceback (most recent call last):
  File "/Users/ayush/nzpy_customer_issue/test.py", line 6, in <module>
    conn = nzpy.connect(user="admin",
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ayush/nzpy_customer_issue/local_venv/lib/python3.11/site-packages/nzpy/__init__.py", line 63, in connect
    return Connection(user, host, unix_sock, port, database, password, ssl,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ayush/nzpy_customer_issue/local_venv/lib/python3.11/site-packages/nzpy/core.py", line 1528, in __init__
    raise ProgrammingError("Error in handshake")
nzpy.core.ProgrammingError: Error in handshake
```

Case 3:
securityLevel = 0
skipCertVerification = False provided explicitly
cacert provided
```
import nzpy
import logging

logging.basicConfig(filename="testnzpy.log")

conn = nzpy.connect(user="admin",
                    password="password",
                    host='abs-nzlite1.fyre.ibm.com',
                    port=5480,
                    database="system",
                    ssl={'ca_certs':'./cacert.pem'},
                    securityLevel=0,
                    logLevel=logging.DEBUG,
                    logOptions=nzpy.LogOptions.Logfile | nzpy.LogOptions.Inherit,
                    char_varchar_encoding='utf8',
                    skipCertVerification = False
                    )
print(f"Connection created successfully")
```
```
(local_venv) ayush@Mac nzpy_customer_issue % python3 test.py
Connection created successfully
```

Case 4:
securityLevel = 2
no param for skipCertVerification provided
cacert not provided 
```
import nzpy
import logging

logging.basicConfig(filename="testnzpy.log")

conn = nzpy.connect(user="admin",
                    password="password",
                    host='abs-nzlite1.fyre.ibm.com',
                    port=5480,
                    database="system",
                    # ssl={'ca_certs':'./cacert.pem'},
                    securityLevel=2,
                    logLevel=logging.DEBUG,
                    logOptions=nzpy.LogOptions.Logfile | nzpy.LogOptions.Inherit,
                    char_varchar_encoding='utf8',
                    # skipCertVerification = False
                    )
print(f"Connection created successfully")
```
Error in handshake
```
python3 test.py
Traceback (most recent call last):
  File "/Users/ayush/nzpy_customer_issue/test.py", line 6, in <module>
    conn = nzpy.connect(user="admin",
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ayush/nzpy_customer_issue/local_venv/lib/python3.11/site-packages/nzpy/__init__.py", line 63, in connect
    return Connection(user, host, unix_sock, port, database, password, ssl,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ayush/nzpy_customer_issue/local_venv/lib/python3.11/site-packages/nzpy/core.py", line 1528, in __init__
    raise ProgrammingError("Error in handshake")
```
Case 5:
securityLevel = 2
no param for skipCertVerification provided
no cacert provided 
```
import nzpy
import logging

logging.basicConfig(filename="testnzpy.log")

conn = nzpy.connect(user="admin",
                    password="password",
                    host='abs-nzlite1.fyre.ibm.com',
                    port=5480,
                    database="system",
                    ssl={'ca_certs':'./cacert.pem'},
                    securityLevel=2,
                    logLevel=logging.DEBUG,
                    logOptions=nzpy.LogOptions.Logfile | nzpy.LogOptions.Inherit,
                    char_varchar_encoding='utf8',
                    # skipCertVerification = False
                    )
print(f"Connection created successfully")
```
```
(local_venv) ayush@Mac nzpy_customer_issue % python3 test.py
Connection created successfully
```
Case 6:
securityLevel = 2
skipCertVerification set to true
cacert not provided 
```
import nzpy
import logging

logging.basicConfig(filename="testnzpy.log")

conn = nzpy.connect(user="admin",
                    password="password",
                    host='abs-nzlite1.fyre.ibm.com',
                    port=5480,
                    database="system",
                    # ssl={'ca_certs':'./cacert.pem'},
                    securityLevel=2,
                    logLevel=logging.DEBUG,
                    logOptions=nzpy.LogOptions.Logfile | nzpy.LogOptions.Inherit,
                    char_varchar_encoding='utf8',
                    skipCertVerification = True
                    )
print(f"Connection created successfully")
```
```
(local_venv) ayush@Mac nzpy_customer_issue % python3 test.py
Connection created successfully
```
